### PR TITLE
fix #3

### DIFF
--- a/src/Command/ModelCommand.php
+++ b/src/Command/ModelCommand.php
@@ -679,6 +679,10 @@ class ModelCommand extends HyperfCommand
 
         $types = $this->extractReflectionTypes($returnType);
 
+        if (is_string($types)) {
+            $types = [$types];
+        }
+
         if ($returnType->allowsNull()) {
             $types[] = 'null';
         }


### PR DESCRIPTION
fix #3

修复 `ModelCommand::getReturnTypeFromReflection` 方法中 `$types` 变量可能为 `string` 类型，在输出时使用 

```php
return implode('|', $types);
```

会导致报错